### PR TITLE
COU-190 Indicate if there is currently no Internet connectivity

### DIFF
--- a/Sources/APLNetworkLayer/HTTPClientConcrete.swift
+++ b/Sources/APLNetworkLayer/HTTPClientConcrete.swift
@@ -300,6 +300,17 @@ extension HTTPClientConcrete: URLSessionDataDelegate {
         completionHandler(request)
     }
 
+    // MARK: - Connectivity Handling
+
+    public func urlSession(_ session: URLSession, taskIsWaitingForConnectivity task: URLSessionTask) {
+        guard let httpTaskDelegate = self.httpTaskDelegate,
+            let httpTask = getTaskThreadSafe(taskIdentifier: task.taskIdentifier) else {
+            return
+        }
+
+        httpTaskDelegate.httpClient(self, httpTaskIsWaitingForConnectivity: httpTask)
+    }
+
     /**
      Handles when the task is completed and will not be retried anymore.
      - Parameter httpTask: The task that has been completed.

--- a/Sources/APLNetworkLayer/HTTPTaskDelegate.swift
+++ b/Sources/APLNetworkLayer/HTTPTaskDelegate.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 
-/// A decision handler on whether or not to cache 'GET' request responses
+/// A delegate for httpTask-level events
 public protocol HTTPTaskDelegate: class {
 
     /// Ask the delegate whether or not a certain request response should
@@ -21,4 +21,12 @@ public protocol HTTPTaskDelegate: class {
     /// with the answer on whether to cache the proposed cache entry or not.
 
     func httpClient(_ httpClient: HTTPClient, httpTask: HTTPTask, willCacheResponse proposedResponse: CachedURLResponse, completionHandler: @escaping (CachedURLResponse?) -> Void)
+
+
+    /// Informs the delegate that a httpTask is waiting for network
+    /// connectivity, e.g. because the device is offline.
+    /// - Parameters: httpClient the HTTP client on which the request has
+    /// been initiated
+    /// - Parameters: httpTask the corresponding http task
+    func httpClient(_ httpClient: HTTPClient, httpTaskIsWaitingForConnectivity httpTask: HTTPTask)
 }


### PR DESCRIPTION
I actually intended to add an observable property to HTTPTask like "waitingForConnectivity".

However, conditional (@available(iOS 13, *)) extensions cannot be added to protocol types for various reasons.

So after all the httpTask delegate was extended by the taskIsWaitingForConnectivity method.