### PR TITLE
Add a way to veto a request in didCreateRequest

### DIFF
--- a/Sources/APLNetworkLayer/HTTPClientConcrete.swift
+++ b/Sources/APLNetworkLayer/HTTPClientConcrete.swift
@@ -107,9 +107,16 @@ public class HTTPClientConcrete: NSObject, HTTPClient {
      */
     private func prepareTaskForStart(httpTask: HTTPTaskConcrete, requestDelegate: RequestDelegate? = nil, startTaskManually: Bool = false) {
         if let requestDelegate = requestDelegate {
-            requestDelegate.didCreateRequest(urlRequest: httpTask.urlRequest) { request in
-                httpTask.urlRequest = request
-                self.createURLSessionTask(httpTask: httpTask, startTaskManually: startTaskManually)
+            requestDelegate.didCreateRequest(urlRequest: httpTask.urlRequest) { result in
+                switch result {
+                case .success(let request):
+                    httpTask.urlRequest = request
+                    self.createURLSessionTask(httpTask: httpTask, startTaskManually: startTaskManually)
+
+                case .failure(let error):
+                    self.complete(httpTask: httpTask, error: error)
+                }
+
             }
         } else {
             createURLSessionTask(httpTask: httpTask, startTaskManually: startTaskManually)

--- a/Sources/APLNetworkLayer/RequestDelegate.swift
+++ b/Sources/APLNetworkLayer/RequestDelegate.swift
@@ -13,9 +13,9 @@ public protocol RequestDelegate: class {
     /**
      Is executed before the URL request is executed in the HTTPClient. Call completion handler to proceed.
      - Parameter urlRequest: The URL request that will be executed in the HTTPClient.
-     - Parameter completionHandler: return a new request or the original request if no changes should be applied.
+     - Parameter completionHandler: Call with a successful result with the new request or the original request if no changes should be applied. On failure, report the error that occured, the request will be cancelled.
      */
-    func didCreateRequest(urlRequest: URLRequest,  completionHandler: @escaping (URLRequest) -> Void)
+    func didCreateRequest(urlRequest: URLRequest,  completionHandler: @escaping (Result<URLRequest, Error>) -> Void)
     
     /**
      Is executed when the HTTPClient has received the result of the request before it is processed. Implement what needs to be executed or checked before the result is processed.


### PR DESCRIPTION
The preparation of a request can fail, for instance when necessary access tokens cannot be retrieved or refreshed.

Extend the delegate method by a way to communicate such a failure condition to the network layer so the request is not sent in vain.

Conclusively the error is then passed to the request's completion handler.